### PR TITLE
Add warp true to TextBlock

### DIFF
--- a/lib/teams_connector/builder.rb
+++ b/lib/teams_connector/builder.rb
@@ -76,7 +76,8 @@ module TeamsConnector
     def result_text
       {
         type: 'TextBlock',
-        text: @content
+        text: @content,
+        wrap: true
       }
     end
 

--- a/spec/teams_connector/builder_spec.rb
+++ b/spec/teams_connector/builder_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe TeamsConnector::Builder do
     it 'gives the result as a hash translated to Adaptive Card syntax' do
       is_expected.to match type: 'Container',
                            items: [
-                             { type: 'TextBlock', text: 'Test Text' },
+                             { type: 'TextBlock', text: 'Test Text', wrap: true },
                              { type: 'FactSet', facts: [
                                { title: 'First Fact', value: 'First Fact Text' }
                              ] }


### PR DESCRIPTION
A propriedade warp no TextBlock efetua a quebra de linha das notificações.

Sem o WARP:
![image](https://github.com/Pagnet/teams_connector/assets/2197651/41d6f584-0c56-4ab5-83e5-527d26fa56c4)

Com o WARP:
![image](https://github.com/Pagnet/teams_connector/assets/2197651/53e8567e-d614-4703-8e4c-0b797b67fc51)
